### PR TITLE
Updated assignments for triage.

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,17 +1,17 @@
 # Set the current review czar
-czar: slegendr
+czar: C2Redhat
 
 # Set the backup czar for pull requests authored by czar
-backup: cchung
+backup: bjohnsto
 
 # Triage assignment reference
-triage: slegendr
-triage-next: cchung
+triage: C2Redhat
+triage-next: bjohnsto
 
 # A list of possible triage, review czar and backup assignees
 members:
-  - bjohnsto
   - C2Redhat
+  - bjohnsto
   - raeburn
   - slegendr
 


### PR DESCRIPTION
Re-ordered team list to match the current order where 'C2Redhat' comes before 'bjohnsto' for now.  This order should be fixed once 'raeburn' is assigned once again.