### PR TITLE
Update Triage assignments

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,12 +1,12 @@
 # Set the current review czar
-czar: slegendr
+czar: bjohnsto
 
 # Set the backup czar for pull requests authored by czar
-backup: bjohnsto
+backup: cchung
 
 # Triage assignment reference
-triage: slegendr
-triage-next: bjohnsto
+triage: bjohnsto
+triage-next: cchung
 
 # A list of possible triage, review czar and backup assignees
 members:
@@ -38,7 +38,6 @@ members:
 # Upcoming rotation:
 # Date   | triage/czar | backup
 # -------+-------------+----------
-# 16-Jan | slegendr    | bjohnsto
 # 30-Jan | bjohnsto    | cchung
 # 13-Feb | cchung      | raeburn
 # 27-Feb | raeburn     | slegendr
@@ -46,3 +45,4 @@ members:
 # 26-Mar | bjohnsto    | cchung
 # 09-Apr | cchung      | raeburn
 # 16-Apr | raeburn     | slegendr
+# 30-Apr | slegendr    | bjohnsto

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -10,18 +10,30 @@ triage-next: bjohnsto
 
 # A list of possible triage, review czar and backup assignees
 members:
+  awalsh:
+    Role: advisory
+    Github: rhawalsh
+    Jira: awalsh1
   bjohnsto:
-    Jira: bjohnston
+    Role: rotation
+    Jira: rojohnst
     Github: bjohnsto
   cchung:
+    Role: rotation
     Jira: cchung
     Github: C2Redhat
   raeburn:
+    Role: rotation
     Jira: raeburn
     Github: raeburn
   slegendr:
+    Role: rotation
     Jira: slegendr
     Github: slegendr
+  msakai:
+    Role: advisory
+    Github: lorelei-sakai
+    Jira: msakai
 
 # Upcoming rotation:
 # Date   | triage/czar | backup
@@ -34,12 +46,3 @@ members:
 # 26-Mar | bjohnsto    | cchung
 # 09-Apr | cchung      | raeburn
 # 16-Apr | raeburn     | slegendr
-
-# Members of the team in an advisory role
-advisory-members:
-  msakai:
-    Github: lorelei-sakai
-    Jira: msakai
-  awalsh:
-    Github: rhawalsh
-    Jira: awalsh


### PR DESCRIPTION
Updated the format to keep all team members in the same list so we can use this for name resolution.
Also fixed the Jira assignment names to account for recent changes