### PR TITLE
Change czar name to use correct name for chung

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,5 +1,5 @@
 # Set the current review czar
-czar: cchung
+czar: C2Redhat
 
 # Set the backup czar for pull requests authored by czar
 backup: raeburn


### PR DESCRIPTION
The czar name should be the github name listed below, not the base name. Change it for chung so he gets properly auto assigned.