### PR TITLE
Fix current triage auto assign name.

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,7 +7,7 @@ czar: C2Redhat
 backup: raeburn
 
 # Triage assignment reference
-triage: C2Redhat
+triage: cchung
 triage-next: raeburn
 
 # A list of possible triage, review czar and backup assignees


### PR DESCRIPTION
The triage value should be cchung and not C2Redhat